### PR TITLE
changed wrong script

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ npx claude-code-templates@latest
 ### From GitHub (recommended)
 
 ```bash
-claude plugin marketplace add github:maslennikov-ig/template-bridge
+claude plugin marketplace add maslennikov-ig/template-bridge
 claude plugin install template-bridge@template-bridge-marketplace
 ```
 


### PR DESCRIPTION
in new version of claude this script is broken:

❯ claude plugin marketplace add github:maslennikov-ig/template-bridge ✘ Invalid marketplace source format. Try: owner/repo, https://..., or ./path ❯ claude plugin marketplace add github:maslennikov-ig/template-bridge ✘ Invalid marketplace source format. Try: owner/repo, https://..., or ./path ❯ claude plugin marketplace add maslennikov-ig/template-bridge SSH not configured, cloning via HTTPS: https://github.com/maslennikov-ig/template-bridge.git Refreshing marketplace cache (timeout: 120s)…
Cloning repository (timeout: 120s): https://github.com/maslennikov-ig/template-bridge.git Clone complete, validating marketplace…
Cleaning up old marketplace cache…
✔ Successfully added marketplace: template-bridge-marketplace (declared in user settings)